### PR TITLE
add function to escape xml breaking characters

### DIFF
--- a/agent/Windows/userinstalledapps.ps1
+++ b/agent/Windows/userinstalledapps.ps1
@@ -36,6 +36,16 @@ function Get-Sid
 	return ""
 }
 
+# Function to escape values 
+function Escape-Xml {
+    param([AllowNull()][string]$Value)
+    if ($Value -eq $null) {
+        return ""
+    }
+
+    return [System.Security.SecurityElement]::Escape($Value)
+}
+
 $xml = ""
 
 $profileListPath =  @("Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\*")
@@ -79,10 +89,10 @@ foreach ($user in $users) {
                 $comparator = "*$appname*"
                 if (-Not (@($appnames) -like $comparator)) {
                     $xml += "<USERINSTALLEDAPPS>`n"
-                    $xml += "<USERNAME>" + $username + "</USERNAME>`n"
-                    $xml += "<APPNAME>" + $appname + "</APPNAME>`n"
-                    $xml += "<PUBLISHER>" + $publisher + "</PUBLISHER>`n"
-                    $xml += "<VERSION>" + $version + "</VERSION>`n"
+                    $xml += "<USERNAME>" + (Escape-Xml $username) + "</USERNAME>`n"
+                    $xml += "<APPNAME>" + (Escape-Xml $appname) + "</APPNAME>`n"
+                    $xml += "<PUBLISHER>" + (Escape-Xml $publisher) + "</PUBLISHER>`n"
+                    $xml += "<VERSION>" + (Escape-Xml $version) + "</VERSION>`n"
 				    $xml += "</USERINSTALLEDAPPS>`n"
                 }
                 $appnames += $appname
@@ -113,10 +123,10 @@ $regLocalApplications | ForEach-Object {
 		$comparator = "*$appname*"
         if (-Not (@($appnames) -like $comparator)) {
             $xml += "<USERINSTALLEDAPPS>`n"	
-            $xml += "<USERNAME>" + $username + "</USERNAME>`n"
-            $xml += "<APPNAME>" + $appname + "</APPNAME>`n"
-            $xml += "<PUBLISHER>" + $publisher + "</PUBLISHER>`n"
-            $xml += "<VERSION>" + $version + "</VERSION>`n"  
+            $xml += "<USERNAME>" + (Escape-Xml $username) + "</USERNAME>`n"
+            $xml += "<APPNAME>" + (Escape-Xml $appname) + "</APPNAME>`n"
+            $xml += "<PUBLISHER>" + (Escape-Xml $publisher) + "</PUBLISHER>`n"
+            $xml += "<VERSION>" + (Escape-Xml $version) + "</VERSION>`n"  
 		    $xml += "</USERINSTALLEDAPPS>`n"
         }
         $appnames += $appname

--- a/infos.json
+++ b/infos.json
@@ -3,7 +3,7 @@
   "author" : ["Léa DROGUET"],
   "contributor" : [],
   "supportedAgent" : ["Windows"],
-  "version" : "2.0",
+  "version" : "2.1",
   "licence" : "GPLv2",
   "description" : {
     "fr" : "Récupère les logiciels installés par utilisateurs",


### PR DESCRIPTION
Adds Escape-XML function to replace invalid XML characters in $value with their valid XML equivalent.  Fixes "output is not a valid XML document" when an application name, publisher, or version contains an invalid XML character. Resolves #3 

```
Balena Ltd. <hello@balena.io> becomes Balena Ltd. &lt;hello@balena.io&gt;
AT&T becomes AT&amp;T

```
